### PR TITLE
AllowOverride для конфигурации с апачем

### DIFF
--- a/apache/conf/httpd.conf
+++ b/apache/conf/httpd.conf
@@ -103,8 +103,7 @@ ServerName bitrix
 
 <Directory />
     Options FollowSymLinks
-    AllowOverride none
-    Require all denied
+    AllowOverride ALL
 </Directory>
 
 LogLevel warn


### PR DESCRIPTION
Разрешил AllowOverride в конфигурации с APACHE
Иначе выдавало access denied при обращении к сайту на битриксе