### PR TITLE
[nginx] fix static resources and denies serving

### DIFF
--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -57,11 +57,6 @@ server {
         client_max_body_size 1024m;
     }
 
-    location ~ /upload/ {
-        client_body_buffer_size 1024m;
-        client_max_body_size 1024m;
-    }
-
     location = /favicon.png {
         log_not_found off;
         access_log off;
@@ -97,6 +92,11 @@ server {
 
     location ~ /.gitignore {
         deny all;
+    }
+
+    location ~ /upload/ {
+        client_body_buffer_size 1024m;
+        client_max_body_size 1024m;
     }
 
     error_page 404 /404.html;

--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -78,6 +78,10 @@ server {
         deny all;
     }
 
+    location ~ /.ht {
+        deny all;
+    }
+
     location ~ /.git/ {
         deny all;
     }


### PR DESCRIPTION
Nginx [resolves](http://nginx.org/en/docs/http/request_processing.html) deeper non-regexp match and then first regexp match if it's present. That means that `~ /upload/` on the top of the file is hitting all `/upload/` URLs overriding all regex location with `/upload` is below it.

Also, this PR adds `.ht` ignore to ignore files like `.htaccess`, and hide `.gitignore` and `.git` behind `403` status code not only in the root of the repo but also in any subdirectory.

## Before that fix

`/upload/support/not_image/.htaccess` URL is accessible and served by `/upload` endpoint

`/upload/CNext/516/5164fd8971f9b62a48681acbe3b942ed.png` served by `/upload/ ` endpoint and not receiving proper cashe headers from location `~* ^.+\.(jpg|jpeg|gif|png|...`

## After that fix

`/upload/support/not_image/.htaccess` URL returns `403`

`/upload/CNext/516/5164fd8971f9b62a48681acbe3b942ed.png` served by `~* ^.+\.(jpg|jpeg|gif|png|...` location