### PR TITLE
Add server_name = $host to work in multi-domain env

### DIFF
--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -31,6 +31,8 @@ server {
     location @bitrix {
         fastcgi_pass php-upstream;
         include fastcgi_params;
+        # make SERVER_NAME behave same as HTTP_HOST
+        fastcgi_param SERVER_NAME $host;
         fastcgi_param SCRIPT_FILENAME $document_root/bitrix/urlrewrite.php;
     }
 
@@ -43,6 +45,8 @@ server {
         fastcgi_index index.php;
         fastcgi_send_timeout 21600;
         fastcgi_read_timeout 21600;
+        # make SERVER_NAME behave same as HTTP_HOST
+        fastcgi_param SERVER_NAME $host;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     }
 
@@ -52,6 +56,8 @@ server {
         fastcgi_index index.php;
         fastcgi_send_timeout 21600;
         fastcgi_read_timeout 21600;
+        # make SERVER_NAME behave same as HTTP_HOST
+        fastcgi_param SERVER_NAME $host;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         client_body_buffer_size 1024m;
         client_max_body_size 1024m;


### PR DESCRIPTION
[PHP SERVER_NAME](https://www.php.net/manual/en/reserved.variables.server.php) variable set to `§host` (equal to `HTTP_HOST` out of the box behavior) is a hard requirement for the multi-domain regional setup of [aspro.next](https://aspro.ru/marketplace/solutions/aspro.next/) to work, I can't think of this change breaking something but I do think that having it out of the box might be a good thing for everyone.

Feel free to reject if you can come up with the reasons why this might be harmful.