### PR TITLE
Clarify restrictions, sort regex locations to restrict go first

### DIFF
--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -36,20 +36,6 @@ server {
         fastcgi_param SCRIPT_FILENAME $document_root/bitrix/urlrewrite.php;
     }
 
-    location ~ \.php$ {
-        if (!-f $request_filename) {
-          rewrite  ^(.*)/index.php$  $1/ redirect;
-        }
-        include fastcgi_params;
-        fastcgi_pass php-upstream;
-        fastcgi_index index.php;
-        fastcgi_send_timeout 21600;
-        fastcgi_read_timeout 21600;
-        # make SERVER_NAME behave same as HTTP_HOST
-        fastcgi_param SERVER_NAME $host;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    }
-
     location = /restore.php {
         include fastcgi_params;
         fastcgi_pass php-upstream;
@@ -73,6 +59,10 @@ server {
         access_log off;
     }
 
+    location ~ (/\.ht|/\.git|/\.gitignore|/vendor/|/composer|/bitrix/updates|/bitrix/modules|/upload/support/not_image|/upload/1c_exchange|/bitrix/php_interface|local/modules|local/php_interface|/logs/) {
+        deny all;
+    }
+
     location ~* ^.+\.(jpg|jpeg|gif|png|svg|js|css|mp3|ogg|mpe?g|avi|zip|gz|bz2?|rar|eot|otf|ttf|woff|woff2)$ {
         log_not_found off;
         access_log off;
@@ -80,33 +70,23 @@ server {
         add_header Cache-Control public;
     }
 
-    location ~ (/bitrix/modules|/upload/support/not_image|/bitrix/php_interface|local/modules|local/php_interface) {
-        deny all;
-    }
-
-    location ~ /.ht {
-        deny all;
-    }
-
-    location ~ /.git/ {
-        deny all;
-    }
-
-    location ~ /vendor/ {
-        deny all;
-    }
-
-    location ~ /composer {
-        deny all;
-    }
-
-    location ~ /.gitignore {
-        deny all;
-    }
-
     location ~ /upload/ {
         client_body_buffer_size 1024m;
         client_max_body_size 1024m;
+    }
+
+    location ~ \.php$ {
+        if (!-f $request_filename) {
+          rewrite  ^(.*)/index.php$  $1/ redirect;
+        }
+        include fastcgi_params;
+        fastcgi_pass php-upstream;
+        fastcgi_index index.php;
+        fastcgi_send_timeout 21600;
+        fastcgi_read_timeout 21600;
+        # make SERVER_NAME behave same as HTTP_HOST
+        fastcgi_param SERVER_NAME $host;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     }
 
     error_page 404 /404.html;


### PR DESCRIPTION
This PR:

1. Gets all deny conditions into single regexp, and adds `/bitrix/updates`, `/upload/1c_exchange` and `/logs/` to these conditions as they should be denied in apache2 according to `.htaccess` files but are not denied in the current configuration;
1. Moves .php Nginx regex location to the end of the file to prevent restricted things like `http://hostname/bitrix/updates/update_m1590470536/main/jscore.php` from working;
1. Moves static resources serving to below the deny rule, as otherwise they will be served even from the denied folder: deny regex need to stay first.