### PR TITLE
explicitly install php7.4-dev

### DIFF
--- a/php74/Dockerfile
+++ b/php74/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     php7.4-imagick \
     php7.4-opcache \
     php7.4-zip \
-    php-pear php-dev libmcrypt-dev gcc make autoconf libc-dev pkg-config \
+    php-pear php7.4-dev libmcrypt-dev gcc make autoconf libc-dev pkg-config \
     && pecl install mcrypt-1.0.4 \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 


### PR DESCRIPTION
php-dev started pointing to php8.0-dev recently