### PR TITLE
Bump denies list from BitrixVM nginx configuration

### DIFF
--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -70,9 +70,12 @@ server {
         access_log off;
     }
 
-    location ~ (/\.ht|/\.git|/\.gitignore|/vendor/|/composer|/bitrix/updates|/bitrix/modules|/upload/support/not_image|/upload/1c_exchange|/bitrix/php_interface|local/modules|local/php_interface|/logs/) {
+    location ~ (/\.ht|/\.git|/\.gitignore|\.settings\.php|/composer|/bitrix/backup|/bitrix/updates|/bitrix/modules|/bitrix/php_interface|/bitrix/stack_cache|/bitrix/managed_cache|/bitrix/html_pages/\.|/upload/1c_exchange|local/modules|local/php_interface|/logs/) {
         deny all;
     }
+
+    # Internal location
+    location ^~ /upload/support/not_image	{ internal; }
 
     location ~* ^.+\.(jpg|jpeg|gif|png|svg|js|css|mp3|ogg|mpe?g|avi|zip|gz|bz2?|rar|eot|otf|ttf|woff|woff2)$ {
         log_not_found off;
@@ -82,6 +85,9 @@ server {
         # re-add security header
         add_header X-Content-Type-Options nosniff;
     }
+
+    # Disable access for non-static assets (not js and css) in cache location
+    location ~* ^/bitrix/cache { deny all; }
 
     location ~ /upload/ {
         client_body_buffer_size 1024m;


### PR DESCRIPTION
The configuration for BitrixVM is not published anywhere, so I set up a machine with it and downloaded the Nginx configuration in order to figure out what is missing from our configuration.

Example of blocked URLs:

- /bitrix/html_pages/.config.php
- /bitrix/html_pages/.config.php