### PR TITLE
Simplify rewrite of index.php in Nginx

### DIFF
--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -95,8 +95,9 @@ server {
     }
 
     location ~ \.php$ {
-        if (!-f $request_filename) {
-          rewrite  ^(.*)/index.php$  $1/ redirect;
+        # redirect index.php to page without it
+        if ($request_uri ~* "^(.*/)index\.php$") {
+            return 301 $1;
         }
         include fastcgi_params;
         fastcgi_pass php-upstream;


### PR DESCRIPTION
Nginx documentation:

> The return directive is the simpler of the two general‑purpose directives and for that reason we recommend using it instead of rewrite when possible