### PR TITLE
Add a note about memcached to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ https://github.com/bitrixdock/production-single-node
 Ещё один проект с php7 и отправкой почты, взят с боевого проекта, вырезаны пароли, сертификаты и тп
 https://github.com/bitrixdock/bitrixdock-production
 
-Ещё один production проект с php7.4, почтой и кроном в контейнере и развёрнутым Readme (англ.):
+Ещё один production проект с memcached композитом, php7.4, почтой и кроном в контейнере и развёрнутым Readme (англ.):
 https://github.com/paskal/bitrix.infra
 
 Реальные проекты на основе этих проектов работают годами без проблем если их не трогать )


### PR DESCRIPTION
I'm using Memcached composite for Bitrix in my project and I thought that adding its Nginx code there would complicate this project without benefits for the developers using it , so instead this PR just mentions where can you check Memcached settings for users who are interested in it.