### PR TITLE
Убрал открытие порта в php по умолчанию

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
         build: ./${PHP_VERSION}
         volumes_from:
             - source
-        ports:
-            - '127.0.0.1:9000:9000'
         links:
             - db
             - memcached


### PR DESCRIPTION
Не стоит явно открывать наружу порт для php-fpm, достаточно того, что он экспоузится. Nginx видет его внутри сети и может по нему обращаться