### PR TITLE
install.sh исправлен баг проверки установленных команд

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,9 +5,9 @@ set -e
 #   $ curl -fsSL https://raw.githubusercontent.com/bitrixdock/bitrixdock/master/install.sh -o install.sh | sh install.sh
 
 echo "Check requirments"
-[ ! hash git ] && apt-get install -y git
-[ ! hash docker ] && cd /usr/local/src && wget -qO- https://get.docker.com/ | sh
-[ ! hash docker-compose ] && curl -L "https://github.com/docker/compose/releases/download/1.25.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose && source ~/.bashrc
+hash git 2>/dev/null || { apt-get install -y git; }
+hash docker 2>/dev/null || { cd /usr/local/src && wget -qO- https://get.docker.com/ | sh; }
+hash docker-compose 2>/dev/null || { curl -L "https://github.com/docker/compose/releases/download/1.25.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose && source ~/.bashrc; }
 
 echo "Create folder struct"
 mkdir -p /var/www/bitrix && \


### PR DESCRIPTION
При проверке существования команд git, docker, docker-compose скрипт падал с ошибкой [: hash: unary operator expected. Было в [issue](https://github.com/bitrixdock/bitrixdock/issues/91#issuecomment-734738510).
Данный pull request решает эту проблему.