### PR TITLE
Добавлен конфиг PHP 8.1

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -1,7 +1,7 @@
 # Project name to separate multiple bitrixdock instances
 COMPOSE_PROJECT_NAME=bitrixdock
 
-# PHP version settings. Allowed value is php56, php71, php73, php74 or php80.
+# PHP version settings. Allowed values are: php56, php71, php73, php74, php80, php81.
 PHP_VERSION=php74
 
 # Web server type. Allowed value is apache or nginx.

--- a/php81/Dockerfile
+++ b/php81/Dockerfile
@@ -1,0 +1,27 @@
+FROM phpdockerio/php:8.1-fpm
+
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install \
+    php8.1-memcached \
+    php8.1-memcache \
+    php8.1-mbstring \
+    php8.1-mysql \
+    php8.1-intl \
+    php8.1-interbase \
+    php8.1-soap \
+    php8.1-gd \
+    php8.1-imagick \
+    php8.1-opcache \
+    php8.1-zip \
+    php-pear php8.1-dev libmcrypt-dev gcc make autoconf libc-dev pkg-config \
+    && pecl install mcrypt-1.0.4 \
+    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+
+COPY ./php.ini /etc/php/8.1/fpm/conf.d/90-php.ini
+COPY ./php.ini /etc/php/8.1/cli/conf.d/90-php.ini
+
+RUN usermod -u 1000 www-data
+
+WORKDIR "/var/www/bitrix"
+
+EXPOSE 9000

--- a/php81/php.ini
+++ b/php81/php.ini
@@ -1,0 +1,24 @@
+[php]
+short_open_tag = On
+display_errors = On
+error_log = "/var/log/php/error.log"
+error_reporting = E_ALL ^ E_DEPRECATED
+log_errors = On
+display_startup_errors = On
+cgi.fix_pathinfo = 0
+date.timezone = "Europe/Moscow"
+mbstring.internal_encoding = "UTF-8"
+max_input_vars = 10000
+post_max_size = 1024M
+memory_limit = 2048M
+upload_max_filesize = 1024M
+extension=mcrypt
+
+[opcache]
+opcache.revalidate_freq = 0
+opcache.validate_timestamps = 1
+opcache.max_accelerated_files = 100000
+opcache.memory_consumption = 512
+opcache.interned_strings_buffer = 64
+opcache.fast_shutdown = 1
+opcache.error_log = "/var/log/php/opcache.log"


### PR DESCRIPTION
Мне удалось запустить сайт на битриксе на PHP 8.1 с последними обновами 😁

![image](https://user-images.githubusercontent.com/33313896/183289554-552112d0-dba9-4f76-b324-54f0633615d0.png)

Но пока в проде не советую обновляться, у битрикса все еще есть ошибки и неисправленные тикеты по совместимости с PHP 8.1
