### PR TITLE
Правки PHP

### DIFF
--- a/php56/php.ini
+++ b/php56/php.ini
@@ -2,7 +2,7 @@
 short_open_tag = On
 display_errors = On
 error_log = "/var/log/php/error.log"
-error_reporting = E_ALL
+error_reporting = E_ALL ^ E_DEPRECATED ^ E_WARNING
 log_errors = On
 display_startup_errors = On
 cgi.fix_pathinfo = 0

--- a/php71/php.ini
+++ b/php71/php.ini
@@ -2,7 +2,7 @@
 short_open_tag = On
 display_errors = On
 error_log = "/var/log/php/error.log"
-error_reporting = E_ALL
+error_reporting = E_ALL ^ E_DEPRECATED ^ E_WARNING
 log_errors = On
 display_startup_errors = On
 cgi.fix_pathinfo = 0

--- a/php73/php.ini
+++ b/php73/php.ini
@@ -2,7 +2,7 @@
 short_open_tag = On
 display_errors = On
 error_log = "/var/log/php/error.log"
-error_reporting = E_ALL
+error_reporting = E_ALL ^ E_DEPRECATED ^ E_WARNING
 log_errors = On
 display_startup_errors = On
 cgi.fix_pathinfo = 0

--- a/php74/php.ini
+++ b/php74/php.ini
@@ -2,7 +2,7 @@
 short_open_tag = On
 display_errors = On
 error_log = "/var/log/php/error.log"
-error_reporting = E_ALL ^ E_DEPRECATED
+error_reporting = E_ALL ^ E_DEPRECATED ^ E_WARNING
 log_errors = On
 display_startup_errors = On
 cgi.fix_pathinfo = 0

--- a/php80/php.ini
+++ b/php80/php.ini
@@ -2,7 +2,7 @@
 short_open_tag = On
 display_errors = On
 error_log = "/var/log/php/error.log"
-error_reporting = E_ALL ^ E_DEPRECATED
+error_reporting = E_ALL ^ E_DEPRECATED ^ E_WARNING
 log_errors = On
 display_startup_errors = On
 cgi.fix_pathinfo = 0

--- a/php81/Dockerfile
+++ b/php81/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     php8.1-opcache \
     php8.1-zip \
     php-pear php8.1-dev libmcrypt-dev gcc make autoconf libc-dev pkg-config \
-    && pecl install mcrypt-1.0.4 \
+    && pecl install mcrypt-1.0.5 \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 COPY ./php.ini /etc/php/8.1/fpm/conf.d/90-php.ini

--- a/php81/php.ini
+++ b/php81/php.ini
@@ -2,7 +2,7 @@
 short_open_tag = On
 display_errors = On
 error_log = "/var/log/php/error.log"
-error_reporting = E_ALL ^ E_DEPRECATED
+error_reporting = E_ALL ^ E_DEPRECATED ^ E_WARNING
 log_errors = On
 display_startup_errors = On
 cgi.fix_pathinfo = 0


### PR DESCRIPTION
Со старым mycrypt в PHP 8.1 ловил ошибки в консоле:

![image](https://user-images.githubusercontent.com/33313896/211190048-dec59245-f748-4af7-a165-55c47ee480f3.png)


+ Отключил вывод варнингов и депрекейтов по умолчанию (при желании их можно посмотреть в админке /bitrix/admin/perfmon_error_list.php?lang=ru или вывести в свой лог)