### PR TITLE
mcrypt-1.0.6 для актуальной версии образа с php 8.2

### DIFF
--- a/php82/Dockerfile
+++ b/php82/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
     php8.2-opcache \
     php8.2-zip \
     php-pear php8.2-dev libmcrypt-dev gcc make autoconf libc-dev pkg-config \
-    && pecl install mcrypt-1.0.5 \
+    && pecl install mcrypt-1.0.6 \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 COPY ./php.ini /etc/php/8.2/fpm/conf.d/90-php.ini


### PR DESCRIPTION
С текущим конфигом mcrypt не устанавливается:

```
root@b09a3ae452c2:/var/www/bitrix# pecl install mcrypt-1.0.5
pecl/mcrypt requires PHP (version >= 7.2.0, version <= 8.2.0, excluded versions: 8.2.0), installed version is 8.2.3
No valid packages found
install failed
```

Возможно, это работало, пока версию php не подняли (текущая 8.2.3). С [mcrypt-1.0.6](https://pecl.php.net/package/mcrypt) все работает корректно