### PR TITLE
Enable JIT for PHP 8.0+

### DIFF
--- a/php80/php.ini
+++ b/php80/php.ini
@@ -15,6 +15,9 @@ upload_max_filesize = 1024M
 extension=mcrypt
 
 [opcache]
+; JIT would be enabled only if XDebug extensions is disabled
+opcache.jit=1255
+opcache.jit_buffer_size=100M
 opcache.revalidate_freq = 0
 opcache.validate_timestamps = 1
 opcache.max_accelerated_files = 100000

--- a/php81/php.ini
+++ b/php81/php.ini
@@ -15,6 +15,9 @@ upload_max_filesize = 1024M
 extension=mcrypt
 
 [opcache]
+; JIT would be enabled only if XDebug extensions is disabled
+opcache.jit=1255
+opcache.jit_buffer_size=100M
 opcache.revalidate_freq = 0
 opcache.validate_timestamps = 1
 opcache.max_accelerated_files = 100000

--- a/php82/php.ini
+++ b/php82/php.ini
@@ -15,6 +15,9 @@ upload_max_filesize = 1024M
 extension=mcrypt
 
 [opcache]
+; JIT would be enabled only if XDebug extensions is disabled
+opcache.jit=1255
+opcache.jit_buffer_size=100M
 opcache.revalidate_freq = 0
 opcache.validate_timestamps = 1
 opcache.max_accelerated_files = 100000


### PR DESCRIPTION
It gave me a 30% page generation time decrease on the production project (1.0s -> 0.7s)

Won't enable when XDebug is enabled; JIT settings will be ignored then.

Articles about JIT: https://medium.com/@edouard.courty/make-your-php-8-apps-twice-as-fast-opcache-jit-8d3542276595, https://stitcher.io/blog/php-8-jit-setup