### PR TITLE
Изменена установка mcrypt

### DIFF
--- a/php80/Dockerfile
+++ b/php80/Dockerfile
@@ -2,20 +2,21 @@ FROM phpdockerio/php:8.0-fpm
 
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
-    php8.0-memcached \
-    php8.0-memcache \
-    php8.0-mbstring \
-    php8.0-mysql \
-    php8.0-intl \
-    php8.0-interbase \
-    php8.0-soap \
+    php8.0-dev \
     php8.0-gd \
     php8.0-imagick \
+    php8.0-intl \
+    php8.0-interbase \
+    php8.0-mbstring \
+    php8.0-mcrypt \
+    php8.0-memcache \
+    php8.0-memcached \
+    php8.0-mysql \
     php8.0-opcache \
+    php8.0-soap \
     php8.0-zip \
-    php-pear php8.0-dev libmcrypt-dev gcc make autoconf libc-dev pkg-config \
-    && pecl install mcrypt-1.0.4 \
-    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+    php-pear \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 COPY ./php.ini /etc/php/8.0/fpm/conf.d/90-php.ini
 COPY ./php.ini /etc/php/8.0/cli/conf.d/90-php.ini

--- a/php80/php.ini
+++ b/php80/php.ini
@@ -12,12 +12,11 @@ max_input_vars = 10000
 post_max_size = 1024M
 memory_limit = 2048M
 upload_max_filesize = 1024M
-extension=mcrypt
 
 [opcache]
 ; JIT would be enabled only if XDebug extensions is disabled
-opcache.jit=1255
-opcache.jit_buffer_size=100M
+opcache.jit = 1255
+opcache.jit_buffer_size = 100M
 opcache.revalidate_freq = 0
 opcache.validate_timestamps = 1
 opcache.max_accelerated_files = 100000

--- a/php81/Dockerfile
+++ b/php81/Dockerfile
@@ -2,20 +2,21 @@ FROM phpdockerio/php:8.1-fpm
 
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
-    php8.1-memcached \
-    php8.1-memcache \
-    php8.1-mbstring \
-    php8.1-mysql \
-    php8.1-intl \
-    php8.1-interbase \
-    php8.1-soap \
+    php8.1-dev \
     php8.1-gd \
     php8.1-imagick \
+    php8.1-intl \
+    php8.1-interbase \
+    php8.1-mbstring \
+    php8.1-mcrypt \
+    php8.1-memcache \
+    php8.1-memcached \
+    php8.1-mysql \
     php8.1-opcache \
+    php8.1-soap \
     php8.1-zip \
-    php-pear php8.1-dev libmcrypt-dev gcc make autoconf libc-dev pkg-config \
-    && pecl install mcrypt-1.0.5 \
-    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+    php-pear \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 COPY ./php.ini /etc/php/8.1/fpm/conf.d/90-php.ini
 COPY ./php.ini /etc/php/8.1/cli/conf.d/90-php.ini

--- a/php81/php.ini
+++ b/php81/php.ini
@@ -12,12 +12,11 @@ max_input_vars = 10000
 post_max_size = 1024M
 memory_limit = 2048M
 upload_max_filesize = 1024M
-extension=mcrypt
 
 [opcache]
 ; JIT would be enabled only if XDebug extensions is disabled
-opcache.jit=1255
-opcache.jit_buffer_size=100M
+opcache.jit = 1255
+opcache.jit_buffer_size = 100M
 opcache.revalidate_freq = 0
 opcache.validate_timestamps = 1
 opcache.max_accelerated_files = 100000

--- a/php82/Dockerfile
+++ b/php82/Dockerfile
@@ -2,21 +2,21 @@ FROM phpdockerio/php:8.2-fpm
 
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
-    php8.2-memcached \
-    php8.2-memcache \
-    php8.2-mbstring \
-    php8.2-mysql \
-    php8.2-intl \
-    php8.2-interbase \
-    php8.2-redis \
-    php8.2-soap \
+    php8.2-dev \
     php8.2-gd \
     php8.2-imagick \
+    php8.2-intl \
+    php8.2-interbase \
+    php8.2-mbstring \
+    php8.2-mcrypt \
+    php8.2-memcache \
+    php8.2-memcached \
+    php8.2-mysql \
     php8.2-opcache \
+    php8.2-soap \
     php8.2-zip \
-    php-pear php8.2-dev libmcrypt-dev gcc make autoconf libc-dev pkg-config \
-    && pecl install mcrypt-1.0.6 \
-    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+    php-pear \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 COPY ./php.ini /etc/php/8.2/fpm/conf.d/90-php.ini
 COPY ./php.ini /etc/php/8.2/cli/conf.d/90-php.ini

--- a/php82/php.ini
+++ b/php82/php.ini
@@ -12,12 +12,11 @@ max_input_vars = 10000
 post_max_size = 1024M
 memory_limit = 2048M
 upload_max_filesize = 1024M
-extension=mcrypt
 
 [opcache]
 ; JIT would be enabled only if XDebug extensions is disabled
-opcache.jit=1255
-opcache.jit_buffer_size=100M
+opcache.jit = 1255
+opcache.jit_buffer_size = 100M
 opcache.revalidate_freq = 0
 opcache.validate_timestamps = 1
 opcache.max_accelerated_files = 100000


### PR DESCRIPTION
Не знаю для чего мы раньше компилили его через pecl, но сейчас php-mcrypt включен в репку и можно подтянуть его оттуда, причем сразу актуальную версию
![image](https://github.com/bitrixdock/bitrixdock/assets/33313896/1cfd39a6-f250-400e-b07b-92d3623b78ce)

плюс чуток прибрался в файликах