### PR TITLE
Исправление ошибки контейнера php-fpm при инициализации сокета.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ docker compose -p bitrixdock down
 - В настройках подключения требуется указывать имя сервиса, например для подключения к базе нужно указывать "db", а не "localhost". Пример [конфига](configs/.settings.php) с подключением к mysql и memcached.
 - Для загрузки резервной копии в контейнер используйте команду: ```cat /var/www/bitrix/backup.sql | docker exec -i mysql /usr/bin/mysql -u root -p123 bitrix```
 - При использовании php74 в production удалите строку с `php7.4-xdebug` из файла `php74/Dockerfile`, сам факт его установки снижает производительность Битрикса и он должен использоваться только для разработки
-
+- Если контейнер php-fpm выдает ошибку "failed to create new listening socket: socket(): Address family not supported by protocol", то необходимо включить поддержку IPv6 в системе. Например в Ubuntu 22.04 — закомментировать строку в конфиге GRUB "GRUB_CMDLINE_LINUX="ipv6.disable=1"
 ## Отличие от виртуальной машины Битрикс
 Виртуальная машина от разработчиков Битрикс решает ту же задачу, что и BitrixDock - предоставляет готовое окружение. Разница лишь в том, что Docker намного удобнее, проще и легче в поддержке.
 


### PR DESCRIPTION
На некоторых машинах встретил такую ошибку в php-fpm контейнере при попытке запуска.
_php fpm failed to create new listening socket: socket(): Address family not supported by protocol (97) 2023-10-03T13:35:49.361278023Z [03-Oct-2023 16:35:49] ERROR: FPM initialization failed_

Решением оказалось включение поддержки IPv6 в системе. Я работал в Ubuntu 22.04.3 LTS, x86_64 Linux 6.2.0-34-generic. Чтобы включить поддержку IPv6  пришлось закомментировать строку в конфиге GRUB, и проблема исчезла.

nano /etc/default/grub
`#GRUB_CMDLINE_LINUX="ipv6.disable=1`