### PR TITLE
Фикс базового образа apache

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,13 +1,11 @@
-FROM gendosu/alpine-apache:latest
-
-MAINTAINER pavletto
+FROM httpd:alpine
 
 RUN apk add --no-cache apache2-proxy; \
-     addgroup -g 1000 -S www; \
-     adduser -G www -u 1000 -s /bin/sh -D www;
+    addgroup -g 1000 -S www; \
+    adduser -G www -u 1000 -s /bin/sh -D www;
 
 COPY conf /etc/apache2
 
 EXPOSE 80 443
 
-CMD /usr/sbin/httpd -DFOREGROUND 
+CMD /usr/sbin/httpd -DFOREGROUND


### PR DESCRIPTION
Старый образ не обновлялся 6 лет
Фиксит этот issue https://github.com/bitrixdock/bitrixdock/issues/143