### PR TITLE
Switch all wget usages to curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,13 @@ ps: ## Show list containers
 	docker-compose ps
 
 bitrix-setup: create-dir ## Download bitrixsetup.php file to the site path
-	wget http://www.1c-bitrix.ru/download/scripts/bitrixsetup.php -O ${SITE_PATH}/bitrixsetup.php
+	curl -fsSL https://www.1c-bitrix.ru/download/scripts/bitrixsetup.php -o ${SITE_PATH}/bitrixsetup.php
 
 bitrix-restore: create-dir ## Download restore.php file to the site path
-	wget http://www.1c-bitrix.ru/download/scripts/restore.php -O ${SITE_PATH}/restore.php
+	curl -fsSL https://www.1c-bitrix.ru/download/scripts/restore.php -o ${SITE_PATH}/restore.php
 
 bitrix-server-test: create-dir ## Download bitrix_server_test.php file to the site path
-	wget https://dev.1c-bitrix.ru/download/scripts/bitrix_server_test.php -O ${SITE_PATH}/bitrix_server_test.php
+	curl -fsSL https://dev.1c-bitrix.ru/download/scripts/bitrix_server_test.php -o ${SITE_PATH}/bitrix_server_test.php
 
 create-dir: ## Create site path
 	mkdir -p ${SITE_PATH}

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ apt-get update && apt-get install -y git
 ```
 - Docker & Docker-Compose
 ```shell
-cd /usr/local/src && wget -qO- https://get.docker.com/ | sh && \
+cd /usr/local/src && curl -fsSL https://get.docker.com/ | sh && \
 curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
 chmod +x /usr/local/bin/docker-compose && \
 echo "alias dc='docker-compose'" >> ~/.bash_aliases && \
@@ -52,8 +52,7 @@ source ~/.bashrc
 ### Папки и файл Битрикс
 ```shell
 mkdir -p /var/www/bitrix && \
-cd /var/www/bitrix && \
-wget https://www.1c-bitrix.ru/download/scripts/bitrixsetup.php && \
+curl -fsSL https://www.1c-bitrix.ru/download/scripts/bitrixsetup.php -o /var/www/bitrix/bitrixsetup.php && \
 cd /var/www/ && \
 git clone https://github.com/bitrixdock/bitrixdock.git && \
 cd /var/ && chmod -R 775 www/ && chown -R root:www-data www/ && \

--- a/install.sh
+++ b/install.sh
@@ -6,13 +6,12 @@ set -e
 echo "Check requirements"
 apt-get -qq update
 hash git 2>/dev/null || { apt-get install -y git; }
-hash docker 2>/dev/null || { cd /usr/local/src && wget -qO- https://get.docker.com/ | sh; }
+hash docker 2>/dev/null || { cd /usr/local/src && curl -fsSL https://get.docker.com/ | sh; }
 hash docker-compose 2>/dev/null || { curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose; }
 
 echo "Create folder struct"
 mkdir -p /var/www/bitrix && \
-cd /var/www/bitrix && \
-wget https://www.1c-bitrix.ru/download/scripts/bitrixsetup.php && \
+curl -fsSL https://www.1c-bitrix.ru/download/scripts/bitrixsetup.php -o /var/www/bitrix/bitrixsetup.php && \
 cd /var/www/ && \
 git clone https://github.com/bitrixdock/bitrixdock.git && \
 cd /var/ && chmod -R 775 www/ && chown -R root:www-data www/ && \

--- a/install.wsl.sh
+++ b/install.wsl.sh
@@ -5,7 +5,7 @@ echo "Create folder struct"
 mkdir -p /var/www/bitrix && \
 cd /var/www && \
 rm -f /var/www/bitrix/bitrixsetup.php && \
-wget https://www.1c-bitrix.ru/download/scripts/bitrixsetup.php -P /var/www/bitrix/ && \
+curl -fsSL https://www.1c-bitrix.ru/download/scripts/bitrixsetup.php -o /var/www/bitrix/bitrixsetup.php && \
 rm -rf /var/www/bitrixdock && \
 git clone --depth=1 https://github.com/bitrixdock/bitrixdock.git && \
 chmod -R 775 /var/www/bitrix && chown -R root:www-data /var/www/bitrix && \


### PR DESCRIPTION
Both are used currently, but keeping both doesn't make sense. Automatic installation is recommended via curl, so curl is supposed to be installed on the user's machine.

Fix for #190.
