### PR TITLE
Install mcrypt from package for php 8.3

### DIFF
--- a/php/php83/Dockerfile
+++ b/php/php83/Dockerfile
@@ -8,14 +8,14 @@ RUN apt-get update \
     php8.3-intl \
     php8.3-interbase \
     php8.3-mbstring \
+    php8.3-mcrypt \
     php8.3-memcache \
     php8.3-memcached \
     php8.3-mysql \
     php8.3-opcache \
     php8.3-soap \
     php8.3-zip \
-    php-pear libmcrypt-dev gcc make autoconf libc-dev pkg-config \
-    && pecl install mcrypt-1.0.7 \
+    php-pear \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 COPY ./php.ini /etc/php/8.3/fpm/conf.d/90-php.ini

--- a/php/php83/php.ini
+++ b/php/php83/php.ini
@@ -12,7 +12,6 @@ max_input_vars = 10000
 post_max_size = 1024M
 memory_limit = 2048M
 upload_max_filesize = 1024M
-extension = mcrypt
 
 [opcache]
 ; JIT would be enabled only if XDebug extensions is disabled


### PR DESCRIPTION
Previously, mcrypt was not available for php 8.3. It is important to do it in the same manner as otherwise, configs are incompatible.