### PR TITLE
feat: добавлен push-server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,15 @@ services:
         networks:
             - bitrixdock
         restart: unless-stopped
+        extra_hosts:
+            - "bitrix.local:172.18.0.9"
 
     web_server:
         build: ./${WEB_SERVER_TYPE}
         depends_on:
             - source
+            - push-server-sub
+            - push-server-pub
         volumes_from:
             - source
         ports:
@@ -27,7 +31,8 @@ services:
         links:
             - php
         networks:
-            - bitrixdock
+            bitrixdock:
+                ipv4_address: 172.18.0.9
         environment:
             TZ: Europe/Moscow
         stdin_open: true
@@ -82,6 +87,37 @@ services:
         networks:
             - bitrixdock
 
+    push-server-sub:
+        image: ikarpovich/bitrix-push-server
+        networks:
+            - bitrixdock
+        environment:
+            - REDIS_HOST=redis
+            - LISTEN_HOSTNAME=0.0.0.0
+            - LISTEN_PORT=8010
+            - SECURITY_KEY=testtesttest
+            - MODE=sub
+        depends_on:
+            - redis
+
+    push-server-pub:
+        image: ikarpovich/bitrix-push-server
+        networks:
+            - bitrixdock
+        environment:
+            - REDIS_HOST=redis
+            - LISTEN_HOSTNAME=0.0.0.0
+            - LISTEN_PORT=8010
+            - SECURITY_KEY=testtesttest
+            - MODE=pub
+        depends_on:
+            - redis
+
+    redis:
+        image: redis
+        networks:
+            - bitrixdock
+
     source:
         image: alpine:latest
         volumes:
@@ -93,6 +129,7 @@ services:
             - cache:/var/lib/memcached
             - ${SITE_PATH}:/var/www/bitrix
             - /etc/localtime:/etc/localtime/:ro
+            - ./nginx/conf/default.conf:/etc/nginx/conf.d/default.conf
         networks:
             - bitrixdock
 
@@ -104,3 +141,6 @@ volumes:
 
 networks:
     bitrixdock:
+        ipam:
+            config:
+                - subnet: 172.18.0.0/24

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,6 @@ services:
             - cache:/var/lib/memcached
             - ${SITE_PATH}:/var/www/bitrix
             - /etc/localtime:/etc/localtime/:ro
-            - ./nginx/conf/default.conf:/etc/nginx/conf.d/default.conf
         networks:
             - bitrixdock
 

--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -2,7 +2,7 @@ server {
     listen 80 deferred reuseport default;
     listen [::]:80 deferred reuseport default;
 
-    server_name bitrix;
+    server_name bitrix.local bitrix;
     charset utf-8;
     root /var/www/bitrix;
     index index.php index.html bitrixsetup.php;
@@ -12,10 +12,6 @@ server {
 
     # bitrix recommendation, respect server's mime-type and don't try to guess it
     add_header X-Content-Type-Options nosniff;
-
-    if (!-e $request_filename) {
-       rewrite  ^(.*)$  /bitrix/urlrewrite.php last;
-    }
 
     # remove multiple slashes
     # duplicated slashes sometimes will work and won't be rewritten, fixing it in this configuration is tricky
@@ -98,6 +94,39 @@ server {
         # make SERVER_NAME behave same as HTTP_HOST
         fastcgi_param SERVER_NAME $host;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    }
+
+    location /bitrix/pub/ {
+        # IM doesn't wait
+        proxy_ignore_client_abort on;
+        proxy_pass http://push-server-pub:8010;
+    }
+
+    location ~* ^/bitrix/subws/ {
+        access_log off;
+        proxy_pass http://push-server-sub:8010;
+        # http://blog.martinfjordvald.com/2013/02/websockets-in-nginx/
+        # 12h+0.5
+        proxy_max_temp_file_size 0;
+        proxy_read_timeout  43800;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $replace_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+
+    location ~* ^/bitrix/sub/ {
+        access_log off;
+        rewrite ^/bitrix/sub/(.*)$ /bitrix/subws/$1 break;
+        proxy_pass http://push-server-sub:8010;
+        proxy_max_temp_file_size 0;
+        proxy_read_timeout  43800;
+    }
+
+    location ~* ^/bitrix/rest/ {
+        access_log off;
+        proxy_pass http://push-server-pub:8010;
+        proxy_max_temp_file_size 0;
+        proxy_read_timeout  43800;
     }
 
     error_page 404 /404.html;

--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -57,6 +57,16 @@ http {
 
     include /etc/nginx/conf.d/*.conf;
     include /etc/nginx/sites-available/*;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' 'close';
+    }
+
+    map $http_upgrade  $replace_upgrade {
+        default $http_upgrade;
+        '' "websocket";
+    }
 }
 
 daemon off;


### PR DESCRIPTION
Добавил:
1.  готовый образ пуш сервера, спасибо `ikarpovich/bitrix-push-server`
2. убрал ненужный if который вносил side-effect 
3. конфиги для резолвинга хоста `bitrix.local` между контейнерами, необходимо для отправки сообщений из php контейнера в контейнер с пуш сервером через nginx
<img width="975" alt="Screenshot 2025-02-10 at 01 22 45" src="https://github.com/user-attachments/assets/75c41e57-4c6d-4cf8-99f8-ea84bfa0db36" />
<img width="1041" alt="Screenshot 2025-02-10 at 01 46 00" src="https://github.com/user-attachments/assets/8f02d9d5-179b-41f8-b46c-3653eb472d56" />
