### PR TITLE
Рефакторинг и оптимизация настроек БД

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
             - ./${DB_SERVER_TYPE}/init:/docker-entrypoint-initdb.d
             - ./logs/db:/var/log/mysql
             - /etc/localtime:/etc/localtime/:ro
-            - db2:/var/lib/mysql
+            - db:/var/lib/mysql
         ports:
             - '${INTERFACE}:3306:3306'
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,6 @@ services:
             - ${SITE_PATH}:/var/www/bitrix
             - ./logs/php:/var/log/php
             - /etc/localtime:/etc/localtime/:ro
-        links:
-            - db
-            - memcached
         environment:
             TZ: Europe/Moscow
         networks:
@@ -24,8 +21,6 @@ services:
         ports:
             - '${INTERFACE}:80:80'
             - '${INTERFACE}:443:443'
-        links:
-            - php
         networks:
             - bitrixdock
         environment:
@@ -61,8 +56,6 @@ services:
 
     adminer:
         image: dockette/adminer:full
-        links:
-            - db:db
         ports:
             - '${INTERFACE}:8080:80'
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,25 +2,25 @@
 services:
     php:
         build: ./php/${PHP_VERSION}
-        volumes_from:
-            - source
+        volumes:
+            - ${SITE_PATH}:/var/www/bitrix
+            - ./logs/php:/var/log/php
+            - /etc/localtime:/etc/localtime/:ro
         links:
             - db
             - memcached
         environment:
             TZ: Europe/Moscow
-        stdin_open: true
-        tty: true
         networks:
             - bitrixdock
         restart: unless-stopped
 
     web_server:
         build: ./${WEB_SERVER_TYPE}
-        depends_on:
-            - source
-        volumes_from:
-            - source
+        volumes:
+            - ${SITE_PATH}:/var/www/bitrix
+            - ./logs/${WEB_SERVER_TYPE}:/var/log/${WEB_SERVER_TYPE}
+            - /etc/localtime:/etc/localtime/:ro
         ports:
             - '${INTERFACE}:80:80'
             - '${INTERFACE}:443:443'
@@ -30,16 +30,15 @@ services:
             - bitrixdock
         environment:
             TZ: Europe/Moscow
-        stdin_open: true
-        tty: true
         restart: unless-stopped
 
     db:
         build: ./${DB_SERVER_TYPE}
         volumes:
             - ./${DB_SERVER_TYPE}/init:/docker-entrypoint-initdb.d
-        volumes_from:
-            - source
+            - ./logs/db:/var/log/mysql
+            - /etc/localtime:/etc/localtime/:ro
+            - db2:/var/lib/mysql
         ports:
             - '${INTERFACE}:3306:3306'
         environment:
@@ -48,23 +47,16 @@ services:
             MYSQL_PASSWORD: ${MYSQL_PASSWORD}
             MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
             TZ: Europe/Moscow
-        command: mysqld --user=root --sql-mode=""
         networks:
             - bitrixdock
-        stdin_open: true
-        tty: true
         restart: unless-stopped
 
     memcached:
         image: memcached:latest
-        volumes_from:
-            - source
         networks:
             - bitrixdock
         environment:
             TZ: Europe/Moscow
-        stdin_open: true
-        tty: true
         restart: unless-stopped
 
     adminer:
@@ -77,30 +69,16 @@ services:
             UPLOAD: 1024M # upload_max_filesize, post_max_size
             TZ: Europe/Moscow
         restart: unless-stopped
-        stdin_open: true
-        tty: true
-        networks:
-            - bitrixdock
-
-    source:
-        image: alpine:latest
-        volumes:
-            - ./logs/${WEB_SERVER_TYPE}:/var/log/${WEB_SERVER_TYPE}
-            - ./logs/php:/var/log/php
-            - ./logs/db:/var/log/mysql
-            - ./logs/memcached:/var/log/memcached
-            - db:/var/lib/mysql
-            - cache:/var/lib/memcached
-            - ${SITE_PATH}:/var/www/bitrix
-            - /etc/localtime:/etc/localtime/:ro
         networks:
             - bitrixdock
 
 volumes:
     db:
         driver: local
-    cache:
-        driver: local
+        driver_opts:
+            type: none
+            device: /var/lib/docker/volumes/${COMPOSE_PROJECT_NAME}_db/_data
+            o: bind
 
 networks:
     bitrixdock:

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8.0
+FROM mysql:8.0-debian
 
 LABEL org.opencontainers.image.source="https://github.com/bitrixdock/bitrixdock"
 

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -1,11 +1,17 @@
 [mysqld]
-default-time-zone="+03:00"
-innodb_file_per_table=1
-innodb_flush_log_at_trx_commit=2
-sync_binlog=0
-# Try to replace O_DIRECT by O_DSYNC if you have "Operating system error number 22"
-innodb_flush_method=O_DIRECT
-transaction-isolation=READ-COMMITTED
-binlog_cache_size=0
+default-time-zone = "+03:00"
+sync_binlog = 0
+skip-log-bin
+transaction-isolation = READ-COMMITTED
+tmp_table_size = 128M
+max_heap_table_size = 128M
+join_buffer_size = 8M
+skip-name-resolve
 sql_mode=""
 
+innodb_flush_method = O_DIRECT
+innodb_buffer_pool_size = 1G
+innodb_lock_wait_timeout = 50
+innodb_log_buffer_size = 16M
+innodb_log_file_size = 100M
+innodb_flush_log_at_trx_commit = 0


### PR DESCRIPTION
Я заметил такое же поведение https://github.com/bitrixdock/bitrixdock/issues/244 на тяжелых проектах

Оказывается для WSL докер хранит named volumes [внутри VHDX диска](https://docs.docker.com/desktop/features/wsl/best-practices/)
![image](https://github.com/user-attachments/assets/d2e99f06-376b-4d5c-9f82-3048f3c828d2)

Который находится тут
`%USERPROFILE%\AppData\Local\Docker\wsl\disk\docker_data.vhdx`
И монтируется сюда
`\\wsl.localhost\docker-desktop\mnt\docker-desktop-disk\data\docker\volumes`

Из-за этого база работает **очень медленно**

Я перенес volume внутрь WSL (в папку по умолчанию, где они должны создаваться в нативном Linux) и немного подтюнил базу. Скорость чтения / записи ускорилась минимум в 10 раз на WSL2