### PR TITLE
Добавлены healthcheck в PHP Dockerfile

### DIFF
--- a/php/php56/Dockerfile
+++ b/php/php56/Dockerfile
@@ -7,6 +7,9 @@ COPY ./php.ini /etc/php5/cli/conf.d/90-php.ini
 
 RUN usermod -u 1000 www-data
 
+HEALTHCHECK --interval=30s --timeout=10s --retries=10 --start-period=10s \
+    CMD php --ini || exit 1
+
 WORKDIR "/var/www/bitrix"
 
 EXPOSE 9000

--- a/php/php71/Dockerfile
+++ b/php/php71/Dockerfile
@@ -9,6 +9,9 @@ COPY ./php.ini /etc/php/7.1/cli/conf.d/90-php.ini
 
 RUN usermod -u 1000 www-data
 
+HEALTHCHECK --interval=30s --timeout=10s --retries=10 --start-period=10s \
+    CMD php --ini || exit 1
+
 WORKDIR "/var/www/bitrix"
 
 EXPOSE 9000

--- a/php/php73/Dockerfile
+++ b/php/php73/Dockerfile
@@ -26,6 +26,9 @@ COPY ./php.ini /etc/php/7.3/cli/conf.d/90-php.ini
 
 RUN usermod -u 1000 www-data
 
+HEALTHCHECK --interval=30s --timeout=10s --retries=10 --start-period=10s \
+    CMD php --ini || exit 1
+
 WORKDIR "/var/www/bitrix"
 
 EXPOSE 9000

--- a/php/php74/Dockerfile
+++ b/php/php74/Dockerfile
@@ -26,6 +26,9 @@ COPY ./php.ini /etc/php/7.4/cli/conf.d/90-php.ini
 
 RUN usermod -u 1000 www-data
 
+HEALTHCHECK --interval=30s --timeout=10s --retries=10 --start-period=10s \
+    CMD php --ini || exit 1
+
 WORKDIR "/var/www/bitrix"
 
 EXPOSE 9000

--- a/php/php80/Dockerfile
+++ b/php/php80/Dockerfile
@@ -23,6 +23,9 @@ COPY ./php.ini /etc/php/8.0/cli/conf.d/90-php.ini
 
 RUN usermod -u 1000 www-data
 
+HEALTHCHECK --interval=30s --timeout=10s --retries=10 --start-period=10s \
+    CMD php --ini || exit 1
+
 WORKDIR "/var/www/bitrix"
 
 EXPOSE 9000

--- a/php/php81/Dockerfile
+++ b/php/php81/Dockerfile
@@ -23,6 +23,9 @@ COPY ./php.ini /etc/php/8.1/cli/conf.d/90-php.ini
 
 RUN usermod -u 1000 www-data
 
+HEALTHCHECK --interval=30s --timeout=10s --retries=10 --start-period=10s \
+    CMD php --ini || exit 1
+
 WORKDIR "/var/www/bitrix"
 
 EXPOSE 9000

--- a/php/php82/Dockerfile
+++ b/php/php82/Dockerfile
@@ -23,6 +23,9 @@ COPY ./php.ini /etc/php/8.2/cli/conf.d/90-php.ini
 
 RUN usermod -u 1000 www-data
 
+HEALTHCHECK --interval=30s --timeout=10s --retries=10 --start-period=10s \
+    CMD php --ini || exit 1
+
 WORKDIR "/var/www/bitrix"
 
 EXPOSE 9000

--- a/php/php83/Dockerfile
+++ b/php/php83/Dockerfile
@@ -24,6 +24,9 @@ COPY ./php.ini /etc/php/8.3/cli/conf.d/90-php.ini
 
 RUN usermod -u 1000 www-data
 
+HEALTHCHECK --interval=30s --timeout=10s --retries=10 --start-period=10s \
+    CMD php --ini || exit 1
+
 WORKDIR "/var/www/bitrix"
 
 EXPOSE 9000

--- a/php/php84/Dockerfile
+++ b/php/php84/Dockerfile
@@ -25,6 +25,9 @@ COPY ./php.ini /etc/php/8.4/cli/conf.d/90-php.ini
 RUN usermod -u 2000 ubuntu
 RUN usermod -u 1000 www-data
 
+HEALTHCHECK --interval=30s --timeout=10s --retries=10 --start-period=10s \
+    CMD php --ini || exit 1
+
 WORKDIR "/var/www/bitrix"
 
 EXPOSE 9000


### PR DESCRIPTION
## Summary
- Добавлены healthcheck для всех PHP контейнеров (5.6, 7.1, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4)
- Используется команда `php --ini` для проверки работоспособности PHP
- Настройки: интервал 30с, таймаут 10с, 10 повторов, период запуска 10с

Часть решения для https://github.com/bitrixdock/bitrixdock/issues/238

Build для 8.0 сломан, решил добавить изменения и туда для консистентности.