### PR TITLE
Фикс percona контейнера

### DIFF
--- a/percona/Dockerfile
+++ b/percona/Dockerfile
@@ -3,9 +3,3 @@ FROM --platform=linux/amd64 percona:8.0
 LABEL org.opencontainers.image.source="https://github.com/bitrixdock/bitrixdock"
 
 COPY my.cnf /etc/mysql/conf.d/my.cnf
-
-USER root
-
-CMD ["mysqld"]
-
-EXPOSE 3306


### PR DESCRIPTION
Начиная с какой-то версии mysql нельзя запускать из под рута
```
2025-06-16T18:17:35.954408Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.42-33) starting as process 1

2025-06-16T18:17:35.955411Z 0 [ERROR] [MY-010123] [Server] Fatal error: Please read "Security" section of the manual to find out how to run mysqld as root!

2025-06-16T18:17:35.955458Z 0 [ERROR] [MY-010119] [Server] Aborting
```