### PR TITLE
Улучшена конфигурация memcached

### DIFF
--- a/configs/.settings.php
+++ b/configs/.settings.php
@@ -17,7 +17,7 @@ return [
             'mode' => 'default',
             'handlers' => [
                 'general' => [
-                    'type' => 'memcache',
+                    'type' => 'memcached',
                     'keyPrefix' => '#01',
                     'port' => 11211,
                     'host' => 'memcached',
@@ -27,12 +27,25 @@ return [
     ],
     'cache' => [
         'value' => [
-            'type' => 'memcache',
+            'type' => 'memcached',
             'sid' => 'master',
-            'memcache' => [
+            'memcached' => [
                 'host' => 'memcached',
                 'port' => '11211',
             ],
+
+            // Сериализатор igbinary уменьшает размер кэша на ~50% по сравнению с
+            // стандартным PHP-сериализатором и работает быстрее при десериализации.
+            // Значение 2 = Memcached::SERIALIZER_IGBINARY
+            // Требует установленного расширения php-igbinary
+            'serializer' => 2,
+
+            // Режим блокировки (use_lock) предотвращает одновременную регенерацию
+            // кэша несколькими процессами. При высокой нагрузке только один процесс
+            // генерирует кэш, остальные получают устаревшие данные.
+            // Требует главного модуля (main) версии 24.0.0 или выше.
+            // Подробнее: https://dev.1c-bitrix.ru/learning/course/?COURSE_ID=43&LESSON_ID=3485
+             'use_lock' => true,
         ],
         'readonly' => true,
     ],


### PR DESCRIPTION
Улучшена конфигурация memcached

1. Заменён устаревший memcache на memcached
   - Старое расширение php-memcache плохо работает в PHP 8+
   - Новое расширение php-memcached стабильно и быстрее работает
   - Исправлены проблемы с производительностью при высокой нагрузке

2. Добавлен сериализатор igbinary
   - Уменьшает размер кэша в два раза
   - Быстрее читает данные из кэша
   - Снижает нагрузку на CPU

3. Добавлена опция use_lock
   - Предотвращает одновременную перегенерацию кэша
   - Полезна для высоконагруженных сайтов
   - Требует главный модуль Bitrix версии 24.0.0+