### PR TITLE
Исправлен драйвер сессий с memcached на memcache

### DIFF
--- a/configs/.settings.php
+++ b/configs/.settings.php
@@ -17,7 +17,7 @@ return [
             'mode' => 'default',
             'handlers' => [
                 'general' => [
-                    'type' => 'memcached',
+                    'type' => 'memcache',
                     'keyPrefix' => '#01',
                     'port' => 11211,
                     'host' => 'memcached',


### PR DESCRIPTION
## Описание

Исправлен драйвер сессий в конфигурации: изменен с `memcached` на `memcache`, так как сессии не поддерживают новый драйвер memcached.

## Изменения

- `configs/.settings.php`: изменен тип драйвера сессий с `memcached` на `memcache`