### PR TITLE
Исправлена загрузка PECL-пакетов для EOL-версий PHP

### DIFF
--- a/php/php73/Dockerfile
+++ b/php/php73/Dockerfile
@@ -27,9 +27,13 @@ RUN apt-get update \
     soap \
     zip \
     opcache \
-    && pecl install memcache-4.0.5.2 \
-    && pecl install memcached-3.2.0 \
-    && pecl install imagick \
+    && curl -fSL -o /tmp/memcache.tgz https://pecl.php.net/get/memcache-4.0.5.2.tgz \
+    && curl -fSL -o /tmp/memcached.tgz https://pecl.php.net/get/memcached-3.4.0.tgz \
+    && curl -fSL -o /tmp/imagick.tgz https://pecl.php.net/get/imagick-3.8.1.tgz \
+    && pecl install /tmp/memcache.tgz \
+    && pecl install /tmp/memcached.tgz \
+    && pecl install /tmp/imagick.tgz \
+    && rm -f /tmp/memcache.tgz /tmp/memcached.tgz /tmp/imagick.tgz \
     && docker-php-ext-enable memcache memcached imagick \
     && apt-get install -y --no-install-recommends \
     libfreetype6 \

--- a/php/php74/Dockerfile
+++ b/php/php74/Dockerfile
@@ -27,9 +27,13 @@ RUN apt-get update \
     soap \
     zip \
     opcache \
-    && pecl install memcache-4.0.5.2 \
-    && pecl install memcached-3.2.0 \
-    && pecl install imagick \
+    && curl -fSL -o /tmp/memcache.tgz https://pecl.php.net/get/memcache-4.0.5.2.tgz \
+    && curl -fSL -o /tmp/memcached.tgz https://pecl.php.net/get/memcached-3.4.0.tgz \
+    && curl -fSL -o /tmp/imagick.tgz https://pecl.php.net/get/imagick-3.8.1.tgz \
+    && pecl install /tmp/memcache.tgz \
+    && pecl install /tmp/memcached.tgz \
+    && pecl install /tmp/imagick.tgz \
+    && rm -f /tmp/memcache.tgz /tmp/memcached.tgz /tmp/imagick.tgz \
     && docker-php-ext-enable memcache memcached imagick \
     && apt-get install -y --no-install-recommends \
     libfreetype6 \

--- a/php/php80/Dockerfile
+++ b/php/php80/Dockerfile
@@ -27,9 +27,13 @@ RUN apt-get update \
     soap \
     zip \
     opcache \
-    && pecl install memcache-8.0 \
-    && pecl install memcached-3.2.0 \
-    && pecl install imagick \
+    && curl -fSL -o /tmp/memcache.tgz https://pecl.php.net/get/memcache-8.2.tgz \
+    && curl -fSL -o /tmp/memcached.tgz https://pecl.php.net/get/memcached-3.4.0.tgz \
+    && curl -fSL -o /tmp/imagick.tgz https://pecl.php.net/get/imagick-3.8.1.tgz \
+    && pecl install /tmp/memcache.tgz \
+    && pecl install /tmp/memcached.tgz \
+    && pecl install /tmp/imagick.tgz \
+    && rm -f /tmp/memcache.tgz /tmp/memcached.tgz /tmp/imagick.tgz \
     && docker-php-ext-enable memcache memcached imagick \
     && apt-get install -y --no-install-recommends \
     libfreetype6 \


### PR DESCRIPTION
## Summary
- Замена `pecl install` на `curl -fSL` + `pecl install` из локального файла для PHP 7.3, 7.4, 8.0
- Обновлены версии расширений до последних стабильных: memcache 8.2, memcached 3.4.0, imagick 3.8.1
- Исправляет проблему из #280 с редиректами на pecl.php.net, ломающими сборку

Fixes https://github.com/bitrixdock/bitrixdock/pull/280#issuecomment-3866973440