### PR TITLE
Исправлен пустой HTTP_HOST при работе через HTTP/3

### DIFF
--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -31,6 +31,8 @@ server {
         include fastcgi_params;
         # make SERVER_NAME behave same as HTTP_HOST
         fastcgi_param SERVER_NAME $host;
+        # pass host to PHP explicitly for HTTP/3 compatibility, where $http_host is empty
+        fastcgi_param HTTP_HOST $host;
         fastcgi_param SCRIPT_FILENAME $document_root/bitrix/urlrewrite.php;
     }
 
@@ -42,6 +44,8 @@ server {
         fastcgi_read_timeout 21600;
         # make SERVER_NAME behave same as HTTP_HOST
         fastcgi_param SERVER_NAME $host;
+        # pass host to PHP explicitly for HTTP/3 compatibility, where $http_host is empty
+        fastcgi_param HTTP_HOST $host;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         client_body_buffer_size 1024m;
         client_max_body_size 1024m;
@@ -93,6 +97,8 @@ server {
         fastcgi_read_timeout 21600;
         # make SERVER_NAME behave same as HTTP_HOST
         fastcgi_param SERVER_NAME $host;
+        # pass host to PHP explicitly for HTTP/3 compatibility, where $http_host is empty
+        fastcgi_param HTTP_HOST $host;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     }
 


### PR DESCRIPTION
## Проблема

В HTTP/3 (QUIC) клиент отправляет псевдо-заголовок `:authority` вместо стандартного `Host:`. В отличие от HTTP/2, nginx **не синтезирует** заголовок `Host:` из `:authority` для HTTP/3-соединений. Из-за этого переменная `$http_host` оказывается пустой, и PHP получает `$_SERVER['HTTP_HOST'] = ''` через FastCGI.

При этом переменная `$host` в nginx работает корректно для всех протоколов — она разрешается из `server_name`, `:authority` или заголовка `Host:` в зависимости от того, что доступно. Пустой оказывается только `$http_host` (буквальное отображение заголовка `Host:` из запроса).

## Что ломается

Любой PHP-код, читающий `$_SERVER['HTTP_HOST']`, получает пустую строку. В случае с Битрикс — модуль безопасности проверяет хост по белому списку и редиректит на URL по умолчанию при неудачной проверке. Пустая строка не проходит проверку → редирект → тот же URL → бесконечный цикл 302-редиректов.

Помимо этого может сломаться: построение URL, мультисайтовая маршрутизация, валидация CSRF, установка домена для кук, генерация канонических URL.

## Исправление

Добавлена одна строка во все три `location`-блока с FastCGI:

```nginx
fastcgi_param  HTTP_HOST  $host;
```

Переменная `$host` всегда содержит корректное значение — она разрешается из `:authority` (HTTP/3), заголовка `Host:` (HTTP/1.1/2) или директивы `server_name` как fallback.

## Контекст

Это известная особенность nginx, отслеженная в [nginx#256](https://github.com/nginx/nginx/issues/256), trac [#2281](https://trac.nginx.org/nginx/ticket/2281) и [#2483](https://trac.nginx.org/nginx/ticket/2483). Команда nginx считает такое поведение корректным, поскольку `:authority` семантически отличается от `Host:`. Plesk автоматически добавляет этот параметр при включении HTTP/3. Проблема затрагивает любой FastCGI-бэкенд (PHP, Python, Ruby) за nginx с включённым HTTP/3.