### PR TITLE
Бамп nginx до 1.28

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.26.2
+FROM nginx:1.28
 
 LABEL org.opencontainers.image.source="https://github.com/bitrixdock/bitrixdock"
 


### PR DESCRIPTION
Nginx 1.28 - текущая LTS версия. Она же (1.28.3) используется по дефу в последней BitrixVM

Т.к. bitrixdock предназначен в основном для разработки, я предлагаю нам НЕ фиксировать его патч версию